### PR TITLE
[FIX] coop_point_of_sale: use product name as journal entry label

### DIFF
--- a/coop_point_of_sale/README.rst
+++ b/coop_point_of_sale/README.rst
@@ -22,16 +22,16 @@ Coop - Point of Sale Custom views
 
 |badge1| |badge2| |badge3|
 
--  Affiche la photo des clients en format grand (champ
-   'res_partner.image') au lieu d'afficher l'image petite.
-   ('res_partner.image_small')
+- Affiche la photo des clients en format grand (champ
+  'res_partner.image') au lieu d'afficher l'image petite.
+  ('res_partner.image_small')
 
 Note: pour un fonctionnement correct, il faut donc que l'image du client
 soit carré dans son format d'origine, pour éviter les distorsions.
 
--  Améliore l'affichage du détail de la fiche client.
--  Stocke le montant total des commandes en bdd pour pouvoir filtrer
-   dessus
+- Améliore l'affichage du détail de la fiche client.
+- Stocke le montant total des commandes en bdd pour pouvoir filtrer
+  dessus
 
 |image|
 
@@ -66,13 +66,14 @@ Authors
 Contributors
 ------------
 
--  Sylvain LE GAL <https://twitter.com/legalsylvain>
--  Julien Weste
--  Iván Todorovich
--  Druidoo <https://www.druidoo.io>
--  Trobz <https://www.trobz.com>
+- Sylvain LE GAL
+  <`https://twitter.com/legalsylvain\\> <https://twitter.com/legalsylvain\>>`__
+- Julien Weste
+- Iván Todorovich
+- Druidoo <`https://www.druidoo.io\\> <https://www.druidoo.io\>>`__
+- Trobz <`https://www.trobz.com\\> <https://www.trobz.com\>>`__
 
-   -  Phan Hong Phuc <<phucph@trobz.com>>
+  - Phan Hong Phuc <<phucph@trobz.com>>
 
 Maintainers
 -----------

--- a/coop_point_of_sale/models/pos_session.py
+++ b/coop_point_of_sale/models/pos_session.py
@@ -143,3 +143,11 @@ class PosSession(models.Model):
 
     def _job_recompute_week_fields_async(self):
         self._compute_week_number()
+
+    def _get_sale_vals(self, key, sale_vals):
+        res = super()._get_sale_vals(key, sale_vals)
+        _account_id, _sign, tax_ids, _base_tag_ids, product_id = key
+        if product_id and not tax_ids:
+            product = self.env["product.product"].browse(product_id)
+            res["name"] = product.display_name
+        return res

--- a/coop_point_of_sale/static/description/index.html
+++ b/coop_point_of_sale/static/description/index.html
@@ -416,11 +416,12 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="contributors">
 <h2><a class="toc-backref" href="#toc-entry-4">Contributors</a></h2>
 <ul class="simple">
-<li>Sylvain LE GAL &lt;<a class="reference external" href="https://twitter.com/legalsylvain">https://twitter.com/legalsylvain</a>&gt;</li>
+<li>Sylvain LE GAL
+&lt;<a class="reference external" href="https://twitter.com/legalsylvain&gt;">https://twitter.com/legalsylvain\&gt;</a></li>
 <li>Julien Weste</li>
 <li>Iván Todorovich</li>
-<li>Druidoo &lt;<a class="reference external" href="https://www.druidoo.io">https://www.druidoo.io</a>&gt;</li>
-<li>Trobz &lt;<a class="reference external" href="https://www.trobz.com">https://www.trobz.com</a>&gt;<ul>
+<li>Druidoo &lt;<a class="reference external" href="https://www.druidoo.io&gt;">https://www.druidoo.io\&gt;</a></li>
+<li>Trobz &lt;<a class="reference external" href="https://www.trobz.com&gt;">https://www.trobz.com\&gt;</a><ul>
 <li>Phan Hong Phuc &lt;&lt;<a class="reference external" href="mailto:phucph&#64;trobz.com">phucph&#64;trobz.com</a>&gt;&gt;</li>
 </ul>
 </li>


### PR DESCRIPTION
## Note:
- You should enable "Closing Entry by product"
<img width="1907" height="857" alt="image" src="https://github.com/user-attachments/assets/053a4418-adaa-45c2-b98f-b3fb54b8d8ff" />

