### PR TITLE
[FIX] foodcoop_data_role: Member Manager should have Invoicing group

### DIFF
--- a/coop_produce/models/stock.py
+++ b/coop_produce/models/stock.py
@@ -1,6 +1,7 @@
 import datetime
 
 from odoo import Command, api, fields, models
+from odoo.exceptions import UserError
 from odoo.osv import expression
 
 
@@ -182,6 +183,14 @@ class StockInventory(models.Model):
 
     def action_add_category_supplier(self):
         self.ensure_one()
+        if self.state != "draft":
+            raise UserError(
+                self.env._(
+                    "You can only add products in draft state. "
+                    "Reset the inventory adjustment first."
+                )
+            )
+            return False
         products = self._get_product_ids()
         if not products:
             return True

--- a/foodcoop_data_role/data/res_users_role.xml
+++ b/foodcoop_data_role/data/res_users_role.xml
@@ -101,6 +101,7 @@
             ref('coop_membership.group_membership_bdm_saisie'),
             ref('coop_membership.coop_group_access_res_partner_inform'),
             ref('base.group_allow_export'),
+            ref('account.group_account_invoice'),
         ])]"
         />
     </record>


### PR DESCRIPTION
In native, user must have "Invoicing" right to post invoice `https://github.com/odoo/odoo/blob/18.0/addons/account/models/account_move.py#L5122`.
So We need to add this group for Member Manager.