### PR TITLE
[FIX] coop_purchase: Purchase Manager group can access Update Price

### DIFF
--- a/coop_purchase/models/account_move.py
+++ b/coop_purchase/models/account_move.py
@@ -93,4 +93,6 @@ class AccountMove(models.Model):
 
     def button_update_prices(self):
         self.ensure_one()
-        return self.env.ref("coop_purchase.supplier_info_update_act").read()[0]
+        return self.env["ir.actions.actions"]._for_xml_id(
+            "coop_purchase.supplier_info_update_act"
+        )

--- a/coop_purchase/models/purchase_order.py
+++ b/coop_purchase/models/purchase_order.py
@@ -6,7 +6,9 @@ class PurchaseOrder(models.Model):
 
     def button_update_prices(self):
         self.ensure_one()
-        return self.env.ref("coop_purchase.supplier_info_update_act").read()[0]
+        return self.env["ir.actions.actions"]._for_xml_id(
+            "coop_purchase.supplier_info_update_act"
+        )
 
     def action_view_invoice(self, invoices=False):
         result = super().action_view_invoice(invoices)

--- a/coop_purchase/security/ir.model.access.csv
+++ b/coop_purchase/security/ir.model.access.csv
@@ -3,3 +3,5 @@ access_supplier_info_update_user,supplier.info.update user,coop_purchase.model_s
 access_supplier_info_update_admin,supplier.info.update admin,coop_purchase.model_supplier_info_update,base.group_system,1,1,1,1
 access_supplier_info_update_line_user,supplier.info.update.line user,coop_purchase.model_supplier_info_update_line,base.group_user,1,1,1,0
 access_supplier_info_update_line_admin,supplier.info.update.line admin,coop_purchase.model_supplier_info_update_line,base.group_system,1,1,1,1
+access_supplier_info_update_purchase_manager,supplier.info.update purchase manager,coop_purchase.model_supplier_info_update,purchase.group_purchase_manager,1,1,1,1
+access_supplier_info_update_line_purchase_manager,supplier.info.update.line purchase manager,coop_purchase.model_supplier_info_update_line,purchase.group_purchase_manager,1,1,1,1


### PR DESCRIPTION
- The action window needs to be called with sudo because internal users do not have access to this model
- Add purchase.group_purchase_manager group who can access to Update Price model