### PR TITLE
[FIX] coop_membership: fix leave view load and clarify leave date error

### DIFF
--- a/coop_membership/__manifest__.py
+++ b/coop_membership/__manifest__.py
@@ -29,6 +29,7 @@
         "sms",
         "spreadsheet_dashboard",
         "base_vat",
+        "base_view_inheritance_extension",
         # "web_widget_image_webcam_portrait",
     ],
     "data": [

--- a/coop_membership/i18n/coop_membership.pot
+++ b/coop_membership/i18n/coop_membership.pot
@@ -1231,6 +1231,13 @@ msgid "Back to Draft"
 msgstr ""
 
 #. module: coop_membership
+#: code:addons/coop_membership/models/shift_leave.py:0
+msgid ""
+"Begin date of the leave should be greater or equal than Begin date of the "
+"work"
+msgstr ""
+
+#. module: coop_membership
 #: model:ir.model.fields,field_description:coop_membership.field_res_partner__badge_distribution_date
 #: model:ir.model.fields,field_description:coop_membership.field_res_users__badge_distribution_date
 msgid "Badge Distribution Date"

--- a/coop_membership/i18n/fr.po
+++ b/coop_membership/i18n/fr.po
@@ -1512,6 +1512,15 @@ msgid "Back to Draft"
 msgstr "Remettre en brouillon"
 
 #. module: coop_membership
+#: code:addons/coop_membership/models/shift_leave.py:0
+msgid ""
+"Begin date of the leave should be greater or equal than Begin date of the "
+"work"
+msgstr ""
+"La date de début du congé doit être postérieure ou égale à la date de début "
+"du travail"
+
+#. module: coop_membership
 #: model:ir.model.fields,field_description:coop_membership.field_res_partner__badge_distribution_date
 #: model:ir.model.fields,field_description:coop_membership.field_res_users__badge_distribution_date
 msgid "Badge Distribution Date"

--- a/coop_membership/models/shift_leave.py
+++ b/coop_membership/models/shift_leave.py
@@ -501,12 +501,16 @@ class ShiftLeave(models.Model):
                 # put end date to template which has closest begin day and
                 # update state leave
                 if last_templates:
-                    last_templates.write(
-                        {
-                            "date_end": fields.Date.from_string(leave.start_date)
-                            - timedelta(days=1)
-                        }
-                    )
+                    leave_start = fields.Date.from_string(leave.start_date)
+                    for line in last_templates:
+                        if leave_start < line.date_begin:
+                            raise ValidationError(
+                                self.env._(
+                                    "Begin date of the leave should be greater"
+                                    " or equal than Begin date of the work"
+                                )
+                            )
+                    last_templates.write({"date_end": leave_start - timedelta(days=1)})
 
         return True
 


### PR DESCRIPTION
**Commit 1: *`f33db2d`***
The res.partner form inheritance uses `<attribute name="context" operation="update">`, which is provided by the OCA module base_view_inheritance_extension. Without depending on it, Odoo core rejects the view at load time with "Invalid attributes 'operation' in element <attribute>".

**Commit 2: *`838c955`***

When confirming a non-defined leave, the member's current shift registration line gets its date_end set to leave.start_date - 1. If the leave starts before the registration line begins, date_end lands before date_begin and the generic "Stop Date should be greater than Start Date" constraint fires, which is confusing.

Raise an explicit message instead ("Begin date of the leave should be greater or equal than Begin date of the work") with FR translation.