### PR TITLE
[FIX] coop_point_of_sale: give POS users read access tp account.partial.reconcile for refund invoicing

### DIFF
--- a/coop_point_of_sale/security/ir.model.access.csv
+++ b/coop_point_of_sale/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_model_pos_config_settings,Manager POS Config Settings,coop_point_of_sale.model_pos_config,point_of_sale.group_pos_manager,1,1,1,0
+access_account_partial_reconcile_pos_user,account.partial.reconcile pos_user,account.model_account_partial_reconcile,point_of_sale.group_pos_user,1,0,0,0


### PR DESCRIPTION
When a POS user clicks "**Invoice**" on a refund order, the flow calls `_apply_invoice_payments`() which reads line.reconciled on the invoice move lines. Computing that field requires reading `account.partial.reconcile`, a model POS users have no access to, raising an Access Error.
Grant `group_pos_user` read-only access to `account.partial.reconcile` so the invoicing flow can compute reconciliation state. All write/reconcile steps in the flow already run with sudo(), so read is enough.